### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 on:
   pull_request: {}
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/elliotwutingfeng/tldextract/security/code-scanning/1](https://github.com/elliotwutingfeng/tldextract/security/code-scanning/1)

To fix the problem, add a `permissions` key to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` and before the `on` key. This will apply the permission restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
